### PR TITLE
add nvram bootstrap infrastructure & rungun nvram

### DIFF
--- a/src/drivers/rungun.c
+++ b/src/drivers/rungun.c
@@ -85,7 +85,29 @@ static NVRAM_HANDLER( rungun )
 			EEPROM_load(file);
 		}
 		else
-			init_eeprom_count = 10;
+    {   
+      static const unsigned char rungun_bootstrap_nvram[] = {
+          4, 20,251,235,146, 71, 69, 65, 65,  0, 21,  3,  7,  3,  0,  0,  0,  0,
+          0,  0,  0,  0,  0, 30,  0, 21, 32,  0,  1,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+          0,  0,
+      }; 
+      
+      file = spawn_bootstrap_nvram(rungun_bootstrap_nvram, sizeof(rungun_bootstrap_nvram));
+      if(file)
+      {
+        init_eeprom_count = 0;
+        EEPROM_load(file);
+      }
+      else
+      {
+        init_eeprom_count = 10;
+      }
+    }
 	}
 }
 

--- a/src/fileio.c
+++ b/src/fileio.c
@@ -5,7 +5,6 @@
 ***************************************************************************/
 
 #include <zlib.h>
-
 #include <assert.h>
 #include "driver.h"
 #include "unzip.h"
@@ -1216,6 +1215,29 @@ int mame_vfprintf(mame_file *f, const char *fmt, va_list va)
 	return mame_fputs(f, buf);
 }
 
+/***************************************************************************
+	spawn_bootstrap_nvram
+  creates a new nvram file for the current romset (as specified in
+  options.romset_filename_noext) using bootstrap_nvram as the source.
+***************************************************************************/
+
+mame_file *spawn_bootstrap_nvram(unsigned char const *bootstrap_nvram, unsigned nvram_length)
+{
+  mame_file *nvram_file = NULL;
+
+  log_cb(RETRO_LOG_INFO, LOGPRE "Generating bootstrap nvram for %s\n", options.romset_filename_noext);
+        
+  nvram_file = mame_fopen(options.romset_filename_noext, 0, FILETYPE_NVRAM, 1);
+  mame_fwrite(nvram_file, bootstrap_nvram, nvram_length);          
+  mame_fclose(nvram_file);
+
+  nvram_file = mame_fopen(options.romset_filename_noext, 0, FILETYPE_NVRAM, 0);
+  
+  if(!nvram_file)
+    log_cb(RETRO_LOG_ERROR, LOGPRE "Error generating nvram bootstrap file!\n");
+  
+  return nvram_file;  
+}
 
 
 /***************************************************************************

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -10,8 +10,10 @@
 #define FILEIO_H
 
 #include <stdarg.h>
+#include <stdio.h>
 #include "osdepend.h"
 #include "hash.h"
+#include "log.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,6 +86,13 @@ UINT64 mame_ftell(mame_file *file);
 
 int mame_fputs(mame_file *f, const char *s);
 int mame_vfprintf(mame_file *f, const char *fmt, va_list va);
+
+/***************************************************************************
+	spawn_bootstrap_nvram
+  creates a new nvram file for the current romset (as specified in
+  options.romset_filename_noext) using bootstrap_nvram as the source.
+***************************************************************************/
+mame_file *spawn_bootstrap_nvram(unsigned char const *bootstrap_nvram, unsigned nvram_length);
 
 #ifdef __GNUC__
 int CLIB_DECL mame_fprintf(mame_file *f, const char *fmt, ...)

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -5,6 +5,7 @@
 #include "mame.h"
 #include "driver.h"
 #include "state.h"
+#include "log.h"
 
 // Wrapper to build MAME on 3DS. It doesn't have stricmp.
 #ifdef _3DS
@@ -115,6 +116,7 @@ static int getDriverIndex(const char* aPath)
     {
        if(strcmp(driverName, drivers[i]->name) == 0)
        {
+          options.romset_filename_noext = strdup(driverName);         
           if (log_cb)
              log_cb(RETRO_LOG_INFO, "Found game: %s [%s].\n", driverName, drivers[i]->name);
           return i;

--- a/src/libretro/log.h
+++ b/src/libretro/log.h
@@ -1,0 +1,17 @@
+#ifndef LOG_H
+#define LOG_H
+
+#include <libretro.h>
+
+/******************************************************************************
+
+	Shared libretro log interface
+    set in mame2003.c 
+
+******************************************************************************/
+
+#define LOGPRE          "[MAME Xtreme] "
+
+extern retro_log_printf_t log_cb;
+
+#endif /* LOG_H */

--- a/src/mame.h
+++ b/src/mame.h
@@ -188,6 +188,8 @@ struct GameOptions
 	mame_file *	record;			/* handle to file to record input to */
 	mame_file *	playback;		/* handle to file to playback input from */
 	mame_file *	language_file;	/* handle to file for localization */
+  
+  char *romset_filename_noext;
 
 	int		mame_debug;		/* 1 to enable debugging */
 	int		cheat;			/* 1 to enable cheating */

--- a/tools/bin2c/bin2c.c
+++ b/tools/bin2c/bin2c.c
@@ -1,0 +1,191 @@
+/*
+ * Converts binary data into a C source file.  The C source file
+ * defines a string with the file name of the source of data, and an
+ * unsigned character array containing the binary data.
+ *
+ * For example, if the source file is dl.lua, the generated file
+ * contains:
+ *
+ * static const char dl_lua_source[] = "dl.lua";
+ *
+ * static const unsigned char dl_lua_bytes[] = {
+ * ...
+ * };
+ *
+ * A useful GNUMakefile rule follows.
+ *
+ * %.h:    %.lua
+ *         luac -o $*.luo $*.lua
+ *         bin2c -o $@ -n $*.lua $*.luo
+ *         rm $*.luo
+ *
+ * John D. Ramsdell
+ * Copyright (C) 2006 The MITRE Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <ctype.h>
+
+#define COLUMNS 18
+
+#ifdef PACKAGE_NAME
+static const char package[] = PACKAGE_NAME;
+#else
+static const char *package = NULL;
+#endif
+
+#ifdef VERSION
+static const char version[] = VERSION;
+#else
+static const char version[] = "version unknown";
+#endif
+
+static void
+print_version(const char *program)
+{
+  if (package != NULL)
+    program = package;
+  fprintf(stderr, "%s %s\n", program, version);
+}
+
+static void
+usage(const char *prog)
+{
+  fprintf(stderr,
+	  "Usage: %s [options] file\n"
+	  "Options:\n"
+	  "  -n name -- generated C identifier source (default is file)\n"
+	  "  -o file -- output to file (default is standard output)\n"
+	  "  -v      -- print version information\n"
+	  "  -h      -- print this message\n",
+	  prog);
+}
+
+static void
+emit_name(const char *name)
+{
+  int ch = *name;
+  if (!ch) {
+    putchar('_');
+    return;
+  }
+  if (isalpha(ch))		/* Print underscore */
+    putchar(ch);		/* when first char is */
+  else				/* is not a letter. */
+    putchar('_');
+  for (;;) {
+    ch = *++name;
+    if (!ch)
+      return;
+    if (isalnum(ch))		/* Print underscore when */
+      putchar(ch);		/* part of identifier is */
+    else			/* not a letter or a digit. */
+      putchar('_');
+  }
+}
+
+static int
+emit(const char *name)
+{
+  int file_length = 0;
+  int col = COLUMNS;
+
+  /*printf("static const char ");
+  emit_name(name);
+  printf("_source[] = \"%s\";\n\n", name);*/
+  printf("static const unsigned char ");
+  emit_name(name);
+  printf("_bytes[] = {");
+  for (;;) {
+    int ch = getchar();
+    if (ch == EOF) {
+      printf("\n};\n\n");
+      printf("static const unsigned int ");
+      emit_name(name);
+      printf("_length = %i;", file_length);      
+      return 0;
+    }
+    if (col >= COLUMNS) {
+      printf("\n  ");
+      col = 0;
+    }
+    printf("%3d,", ch);
+    file_length++;
+    col++;
+  }
+}
+
+int
+main(int argc, char *argv[])
+{
+  extern char *optarg;
+  extern int optind;
+
+  char *input = NULL;
+  char *output = NULL;
+  char *name = NULL;
+
+  for (;;) {
+    int c = getopt(argc, argv, "n:o:vh");
+    if (c == -1)
+      break;
+    switch (c) {
+    case 'n':
+      name = optarg;
+      break;
+    case 'o':
+      output = optarg;
+      break;
+    case 'v':
+      print_version(argv[0]);
+      return 0;
+    case 'h':
+      usage(argv[0]);
+      return 0;
+    default:
+      usage(argv[0]);
+      return 1;
+    }
+  }
+
+  if (argc != optind + 1) {
+    fprintf(stderr, "Bad arg count\n");
+    usage(argv[0]);
+    return 1;
+  }
+
+  input = argv[optind];
+  if (!freopen(input, "rb", stdin)) {
+    perror(input);
+    return 1;
+  }
+
+  if (output && !freopen(output, "w", stdout)) {
+    perror(output);
+    return 1;
+  }
+
+  return emit(name ? name : input);
+}


### PR DESCRIPTION
Hi @KMFDManic I have added here a minimal implementation of the nvram bootstrap functions in order for it to be available in this core. 

I have tested this and it's working for me on Windows 7 x64. Once we're sure this works in the SNES Classic environment it should be possible for us to collaborate on other nvram patches as needed.