### PR TITLE
Hang-On

### DIFF
--- a/src/drivers/sharrier.c
+++ b/src/drivers/sharrier.c
@@ -7,19 +7,233 @@
 **	Space Harrier
 */
 
+/*
+03/11/04  Charles MacDonald
+Various Hang-On fixes:
+- Fixed sprite RAM size.
+- Fixed tile RAM size.
+- Fixed 2nd 68000 work RAM size, passes RAM test.
+- Fixed visibility of 2nd 68000 ROM to 1st 68000, passes ROM test.
+- Fixed access to road RAM and shared RAM by both CPUs.
+- Cleaned up input management, now entering test mode does not crash
+  MAME, there are no specific control hacks for the name entry screen,
+  and the ROM patches are no longer needed.
+  
+To do:
+- Missing color bars in CRT tests
+- Proper Enduro Racer and Space Harrier inputs
+*/
+
 #include "driver.h"
 #include "vidhrdw/generic.h"
 #include "cpu/z80/z80.h"
 #include "cpu/i8039/i8039.h"
 #include "system16.h"
 
+/*
+	Hang-On I/O hardware
+*/
+
+static int latched_analog_input;	/* Selected input to read with ADC */
+static int ppi_reg[2][4];			/* PPI registers */
+
+static WRITE16_HANDLER( hangon_io_w )
+{
+	if( ACCESSING_LSB )
+	{                        
+		switch( offset & 0x003020/2 )
+		{
+			case 0x0000: /* PPI @ 4B */
+				switch( offset & 0x07)
+				{
+					case 0x00: /* Port A : Z80 sound command */
+						ppi_reg[0][0] = data;
+						soundlatch_w(0, data & 0xff);
+						cpu_set_nmi_line(1, PULSE_LINE);
+						return;
+
+					case 0x01: /* Port B : Miscellaneous outputs */
+						ppi_reg[0][1] = data;
+
+						/* D7 : FLIPC (1= flip screen, 0= normal orientation) */
+						/* D6 : SHADE0 (1= highlight, 0= shadow) */
+						/* D4 : /KILL (1= screen on, 0= screen off) */
+						sys16_refreshenable = data & 0x10;
+
+						/* D3 : LAMP2 */
+						set_led_status(1, data & 0x08);
+						
+						/* D2 : LAMP1 */
+						set_led_status(0, data & 0x04);
+						
+						/* D1 : COIN2 */
+						coin_counter_w(1, data & 0x02);
+						
+						/* D0 : COIN1 */
+						coin_counter_w(0, data & 0x01);						
+						return;
+
+					case 0x02: /* Port C : Tilemap origin and audio mute */
+						ppi_reg[0][2] = data;
+
+						/* D2 : SCONT1 - Tilemap origin bit 1 */
+						/* D1 : SCONT0 - Tilemap origin bit 0 */
+						/* D0 : MUTE (1= audio on, 0= audio off) */					
+						
+  						/* Not used */
+						return;
+
+					case 0x03: /* PPI control register */
+						ppi_reg[0][3] = data;
+						return;
+				}
+				break;
+
+		case 0x3000/2: /* PPI @ 4C */
+			switch( offset & 0x07)
+			{
+				case 0x00: /* Port A : S.CPU control and ADC channel select */
+					ppi_reg[1][0] = data;
+				
+#if 0 /* Not sure this is correct */
+
+					/* To S.RES of second CPU */
+					if(data & 0x20)
+					cpu_set_reset_line(2, CLEAR_LINE);
+					else
+					cpu_set_reset_line(2, ASSERT_LINE);
+					
+					/* To S.INT of second CPU */
+					if(data & 0x10)
+					cpu_set_irq_line(2, 1, HOLD_LINE);
+					else
+					cpu_set_irq_line(2, 1, CLEAR_LINE);
+#endif
+					return;
+				
+				case 0x01: /* Port B : High-current outputs */
+					ppi_reg[1][1] = data;		
+					/* Not used */
+					return;
+				
+				case 0x02: /* Port C : LED driver control (?) */
+					ppi_reg[1][2] = data;				
+					/* Not used */
+					return;
+					
+				case 0x03: /* PPI control register */
+					ppi_reg[1][3] = data;
+					return;
+			}
+		break;
+
+		case 0x3020/2: /* ADC0804 */
+			switch(ppi_reg[1][0] & 0x0C)
+			{
+				case 0x00: /* "ANGLE" */
+					latched_analog_input = readinputport(0);
+					return;
+				
+				case 0x04: /* "ACCEL" */
+					latched_analog_input = readinputport(1);
+					return;
+			
+				case 0x08: /* "BRAKE" */
+					latched_analog_input = readinputport(5);
+					return;
+				
+				case 0x0C: /* Not used */
+					latched_analog_input = 0;
+					return;
+			}
+			break;
+		}
+	}
+}
+
+static READ16_HANDLER( hangon_io_r )
+{
+	switch( offset & 0x003020/2 )
+	{
+		case 0x0000: /* PPI @ 4B */
+			switch( offset & 0x07)
+			{
+				case 0x00: /* Port A : Z80 sound command */
+				/*
+				Bidirectional port, but Z80 only ever reads data written
+				by the main 68000.
+				*/
+				return 0xFF;
+			
+				case 0x01: /* Port B */
+					return ppi_reg[0][1];
+				
+				case 0x02: /* Port C */
+					return ppi_reg[0][2];
+				
+				case 0x03: /* PPI control register */
+					return ppi_reg[0][3];
+			}
+			break;
+			
+			case 0x1000/2: /* Input ports and DIP switches */
+				switch( offset & 0x0F )
+				{
+					case 0x00: /* Input port #0 */
+						return readinputport(2);
+			
+					case 0x01: /* Input port #1 */	
+						/* Not used */
+						return 0xFF;
+			
+					case 0x04: /* DIP switch A */
+						return readinputport(3);
+			
+					case 0x06: /* DIP switch B */
+						return readinputport(4);
+				}
+				break;
+			
+			case 0x3000/2: /* PPI @ 4C */
+				switch( offset & 0x07)
+				{
+					case 0x00: /* Port A */
+						return ppi_reg[1][0];
+					
+					case 0x01: /* Port B */
+						return ppi_reg[1][1];
+					
+					case 0x02: /* Port C : ADC status */
+						/*
+						D7 = 0 (left open)
+						D6 = /INTR of ADC0804
+						D5 = 0 (left open)
+						D4 = 0 (left open)
+						
+						We leave /INTR low to indicate converted data is
+						always ready to be read.
+						*/
+						return (ppi_reg[1][2] & 0x0F);
+					
+					case 0x03: /* PPI control register */
+						return ppi_reg[1][3];
+				}
+				break;
+				
+			case 0x3020/2: /* ADC0804 data output */
+				return latched_analog_input;
+	}	
+	
+	return -1;
+}
+
 /***************************************************************************/
 
 static void generate_gr_screen(
-	int w, // 512
-	int bitmap_width, // 1024
-	int skip, // 8
-	int start_color,int end_color, // 0..4
+	int w, /* 512*/
+	int bitmap_width, /* 1024*/
+	int skip, /* 8*/
+	int start_color,int end_color, /* 0..4*/
 	int source_size )
 {
 	/* preprocess road data, expanding it into a form more easily rendered */
@@ -32,13 +246,13 @@ static void generate_gr_screen(
 	    int center_offset=0;
 		sys16_gr_bitmap_width = bitmap_width;
 
-//logerror( "generating road gfx; bitmap_width = %d\n", bitmap_width );
+/*logerror( "generating road gfx; bitmap_width = %d\n", bitmap_width );*/
 
 		memcpy( buf,gr,source_size ); /* copy from ROM to temp buffer */
 		memset( gr,0,256*bitmap_width ); /* erase */
 
 		if( w!=sys16_gr_bitmap_width ){
-			if( skip>0 ) // needs mirrored RHS
+			if( skip>0 ) /* needs mirrored RHS*/
 				grr=gr;
 			else {
 				center_offset= bitmap_width-w;
@@ -46,7 +260,7 @@ static void generate_gr_screen(
 			}
 		}
 
-		for( row_offset=0; row_offset<256; row_offset++ ){ // build gr_bitmap
+		for( row_offset=0; row_offset<256; row_offset++ ){ /* build gr_bitmap*/
 			UINT8 last_bit;
 			UINT8 color_data[4];
 
@@ -60,7 +274,7 @@ static void generate_gr_screen(
 				for( bit_offset=0; bit_offset<8; bit_offset++ ){
 					UINT8 bit=((buf[0]&0x80)==0)|(((buf[0x4000]&0x80)==0)<<1);
 					if( bit!=last_bit && bit==0 && row_offset>1 ){
-						// color flipped to 0? advance color[0]
+						/* color flipped to 0? advance color[0]*/
 						if (color_data[0]+end_color <= end_color){
 							color_data[0]+=end_color;
 						}
@@ -69,15 +283,15 @@ static void generate_gr_screen(
 						}
 					}
 					*gr++ = color_data[bit];
-//					logerror( "%01x", color_data[bit] );
+/*					log_cb(RETRO_LOG_ERROR, LOGPRE  "%01x", color_data[bit] );*/
 					last_bit=bit;
 					buf[0] <<= 1; buf[0x4000] <<= 1;
 				}
 				buf++;
 			}
-//			logerror( "\n" );
+/*			log_cb(RETRO_LOG_ERROR, LOGPRE  "\n" );*/
 
-			if( grr!=NULL ){ // need mirrored RHS
+			if( grr!=NULL ){ /* need mirrored RHS*/
 				const UINT8 *temp = gr-1-skip;
 				for( byte_offset=0; byte_offset<w-skip; byte_offset++){
 					*gr++ = *temp--;
@@ -93,9 +307,9 @@ static void generate_gr_screen(
 		{
 			int i=1;
 			while ( (1<<i) < sys16_gr_bitmap_width ) i++;
-			sys16_gr_bitmap_width=i; // power of 2
+			sys16_gr_bitmap_width=i; /* power of 2*/
 		}
-//		logerror( "width = %d\n", sys16_gr_bitmap_width );
+/*		log_cb(RETRO_LOG_ERROR, LOGPRE  "width = %d\n", sys16_gr_bitmap_width );*/
 		free( buf0 );
 	}
 }
@@ -169,20 +383,29 @@ static WRITE16_HANDLER( sys16_coinctrl_w )
 }
 #endif
 
+/*
+	Hang-On shared road RAM and 68000 #2 work RAM
+*/
 
-static READ16_HANDLER( ho_io_x_r ){ return input_port_0_r( offset ); }
-static READ16_HANDLER( ho_io_y_r ){ return (input_port_1_r( offset ) << 8) + input_port_5_r( offset ); }
+data16_t *hangon_roadram;
+data16_t *hangon_sharedram;
 
-static READ16_HANDLER( ho_io_highscoreentry_r ){
-	int mode= sys16_extraram4[0x3000/2];
-	if( mode&4 ){	// brake
-		if(ho_io_y_r(0,0) & 0x00ff) return 0xffff;
-	}
-	else if( mode&8 ){ // button
-		if(ho_io_y_r(0,0) & 0xff00) return 0xffff;
-	}
-	return 0;
+static READ16_HANDLER( hangon_sharedram_r ) {
+	return hangon_sharedram[offset];
 }
+
+static WRITE16_HANDLER( hangon_sharedram_w ) {
+	COMBINE_DATA( hangon_sharedram + offset );
+}
+
+static READ16_HANDLER( hangon_roadram_r ) {
+	return hangon_roadram[offset];
+}
+
+static WRITE16_HANDLER( hangon_roadram_w ) {
+	COMBINE_DATA( hangon_roadram + offset );
+}
+
 
 static READ16_HANDLER( hangon1_skip_r ){
 	if (activecpu_get_pc()==0x17e6) {cpu_spinuntil_int(); return 0xffff;}
@@ -190,56 +413,48 @@ static READ16_HANDLER( hangon1_skip_r ){
 }
 
 static MEMORY_READ16_START( hangon_readmem )
-	{ 0x000000, 0x03ffff, MRA16_ROM },
+    { 0x000000, 0x03ffff, MRA16_ROM },
 	{ 0x20c400, 0x20c401, hangon1_skip_r },
 	{ 0x20c000, 0x20ffff, SYS16_MRA16_EXTRAM },
-	{ 0x400000, 0x40ffff, SYS16_MRA16_TILERAM },
+	{ 0x400000, 0x403fff, SYS16_MRA16_TILERAM },
 	{ 0x410000, 0x410fff, SYS16_MRA16_TEXTRAM },
-	{ 0x600000, 0x600fff, SYS16_MRA16_SPRITERAM },
+	{ 0x600000, 0x6007ff, SYS16_MRA16_SPRITERAM },
 	{ 0xa00000, 0xa00fff, SYS16_MRA16_PALETTERAM },
-	{ 0xc68000, 0xc68fff, SYS16_MRA16_EXTRAM2 },
-	{ 0xc7e000, 0xc7ffff, SYS16_MRA16_EXTRAM3 },
-	{ 0xe00002, 0xe00003, sys16_coinctrl_r },
-	{ 0xe01000, 0xe01001, input_port_2_word_r }, // service
-	{ 0xe0100c, 0xe0100d, input_port_4_word_r }, // dip2
-	{ 0xe0100a, 0xe0100b, input_port_3_word_r }, // dip1
-	{ 0xe03020, 0xe03021, ho_io_highscoreentry_r },
-	{ 0xe03028, 0xe03029, ho_io_x_r },
-	{ 0xe0302a, 0xe0302b, ho_io_y_r },
+	{ 0xc00000, 0xc0ffff, SYS16_CPU3ROM16_r },
+	{ 0xc68000, 0xc68fff, hangon_roadram_r },
+	{ 0xc7c000, 0xc7ffff, hangon_sharedram_r },
+	{ 0xe00000, 0xffffff, hangon_io_r },
 MEMORY_END
 
 static MEMORY_WRITE16_START( hangon_writemem )
-	{ 0x000000, 0x03ffff, MWA16_ROM },
+    { 0x000000, 0x03ffff, MWA16_ROM },
 	{ 0x20c000, 0x20ffff, SYS16_MWA16_EXTRAM },
-	{ 0x400000, 0x40ffff, SYS16_MWA16_TILERAM },
+	{ 0x400000, 0x403fff, SYS16_MWA16_TILERAM },
 	{ 0x410000, 0x410fff, SYS16_MWA16_TEXTRAM },
-	{ 0x600000, 0x600fff, SYS16_MWA16_SPRITERAM },
+	{ 0x600000, 0x6007ff, SYS16_MWA16_SPRITERAM },
 	{ 0xa00000, 0xa00fff, SYS16_MWA16_PALETTERAM },
-	{ 0xc68000, 0xc68fff, SYS16_MWA16_EXTRAM2 },
-	{ 0xc7e000, 0xc7ffff, SYS16_MWA16_EXTRAM3 },
-	{ 0xe00000, 0xe00001, sound_command_nmi_w },
-	{ 0xe00002, 0xe00003, sys16_3d_coinctrl_w },
-	{ 0xe00004, 0xe00005, MWA16_NOP }, /* ? */
-	{ 0xe02000, 0xe02001, MWA16_NOP }, /* ? */
-	{ 0xe03000, 0xe03001, MWA16_NOP }, /* ? */
+	{ 0xc00000, 0xc3ffff, MWA16_NOP },
+	{ 0xc68000, 0xc68fff, hangon_roadram_w, &hangon_roadram },
+	{ 0xc7c000, 0xc7ffff, hangon_sharedram_w, &hangon_sharedram },
+	{ 0xe00000, 0xffffff, hangon_io_w },
 MEMORY_END
 
 static READ16_HANDLER( hangon2_skip_r ){
 	if (activecpu_get_pc()==0xf66) {cpu_spinuntil_int(); return 0xffff;}
-	return sys16_extraram3[0x01000/2];
+	return hangon_sharedram[0x01000/2];
 }
 
 static MEMORY_READ16_START( hangon_readmem2 )
-	{ 0x000000, 0x03ffff, MRA16_ROM },
+    { 0x000000, 0x03ffff, MRA16_ROM },
 	{ 0xc7f000, 0xc7f001, hangon2_skip_r },
-	{ 0xc68000, 0xc68fff, SYS16_MRA16_EXTRAM2 },
-	{ 0xc7e000, 0xc7ffff, SYS16_MRA16_EXTRAM3 },
+	{ 0xc68000, 0xc68fff, hangon_roadram_r },
+	{ 0xc7c000, 0xc7ffff, hangon_sharedram_r },
 MEMORY_END
 
 static MEMORY_WRITE16_START( hangon_writemem2 )
-	{ 0x000000, 0x03ffff, MWA16_ROM },
-	{ 0xc68000, 0xc68fff, SYS16_MWA16_EXTRAM2 },
-	{ 0xc7e000, 0xc7ffff, SYS16_MWA16_EXTRAM3 },
+    { 0x000000, 0x03ffff, MWA16_ROM },
+	{ 0xc68000, 0xc68fff, hangon_roadram_w },
+	{ 0xc7c000, 0xc7ffff, hangon_sharedram_w },
 MEMORY_END
 
 static MEMORY_READ_START( hangon_sound_readmem )
@@ -269,11 +484,11 @@ PORT_END
 /***************************************************************************/
 
 static void hangon_update_proc( void ){
-	set_page( sys16_bg_page, sys16_textram[0x74e] );
-	set_page( sys16_fg_page, sys16_textram[0x74f] );
+	set_page( sys16_bg_page, sys16_textram[0x74e] & 0x3333 );
+	set_page( sys16_fg_page, sys16_textram[0x74f] & 0x3333 );
 	sys16_fg_scrollx = sys16_textram[0x7fc] & 0x01ff;
 	sys16_bg_scrollx = sys16_textram[0x7fd] & 0x01ff;
-	sys16_fg_scrolly = sys16_textram[0x792] & 0x00ff;
+	sys16_fg_scrolly = sys16_textram[0x792] & 0x01ff;
 	sys16_bg_scrolly = sys16_textram[0x793] & 0x01ff;
 }
 
@@ -287,13 +502,20 @@ static MACHINE_INIT( hangon ){
 	sys16_textlayer_hi_min=0;
 	sys16_textlayer_hi_max=0xff;
 
-	sys16_patch_code( 0x83bd, 0x29);
-	sys16_patch_code( 0x8495, 0x2a);
-	sys16_patch_code( 0x84f9, 0x2b);
+/*  
+	The following patches modified the input code to read the first three
+	analog inputs from unique addresses rather than the single address
+	the ADC is mapped to, so the input selection behavior didn't have to be
+	emulated. Not needed anymore, but left in for reference.
+	
+	sys16_patch_code( 0x83bd, 0x29); /* $E03021 -> $E03029 */
+	sys16_patch_code( 0x8495, 0x2a); /* $E03021 -> $E0302A */
+	sys16_patch_code( 0x84f9, 0x2b); /* $E03021 -> $E0302B */
+*/
 
 	sys16_update_proc = hangon_update_proc;
 
-	sys16_gr_ver = &sys16_extraram2[0x0];
+	sys16_gr_ver = &hangon_roadram[0x0];
 	sys16_gr_hor = sys16_gr_ver+0x200/2;
 	sys16_gr_pal = sys16_gr_ver+0x400/2;
 	sys16_gr_flip= sys16_gr_ver+0x600/2;
@@ -380,9 +602,9 @@ static MEMORY_READ16_START( harrier_readmem )
 	{ 0x124000, 0x127fff, shared_ram_r },
 	{ 0x130000, 0x130fff, SYS16_MRA16_SPRITERAM },
 	{ 0x140002, 0x140003, sys16_coinctrl_r },
-	{ 0x140010, 0x140011, input_port_2_word_r }, // service
-	{ 0x140014, 0x140015, input_port_3_word_r }, // dip1
-	{ 0x140016, 0x140017, input_port_4_word_r }, // dip2
+	{ 0x140010, 0x140011, input_port_2_word_r }, /* service*/
+	{ 0x140014, 0x140015, input_port_3_word_r }, /* dip1*/
+	{ 0x140016, 0x140017, input_port_4_word_r }, /* dip2*/
 	{ 0x140024, 0x140027, sh_motor_status_r },
 	{ 0xc68000, 0xc68fff, SYS16_MRA16_EXTRAM2 },
 MEMORY_END
@@ -469,7 +691,7 @@ static MACHINE_INIT( harrier ){
 	sys16_textlayer_hi_min=0;
 	sys16_textlayer_hi_max=0xff;
 
-//*disable illegal rom writes
+/**disable illegal rom writes*/
 	sys16_patch_code( 0x8112, 0x4a);
 	sys16_patch_code( 0x83d2, 0x4a);
 	sys16_patch_code( 0x83d6, 0x4a);
@@ -559,22 +781,22 @@ static READ16_HANDLER( er_io_analog_r )
 {
 	switch( er_io_analog_sel )
 	{
-		case 0:		// accel
+		case 0:		/* accel*/
 			if(input_port_1_r( offset ) & 1)
 				return 0xff;
 			else
 				return 0;
-		case 4:		// brake
+		case 4:		/* brake*/
 			if(input_port_1_r( offset ) & 2)
 				return 0xff;
 			else
 				return 0;
-		case 8:		// bank up down?
+		case 8:		/* bank up down?*/
 			if(input_port_1_r( offset ) & 4)
 				return 0xff;
 			else
 				return 0;
-		case 12:	// handle
+		case 12:	/* handle*/
 			return input_port_0_r( offset );
 
 	}
@@ -601,9 +823,9 @@ static MEMORY_READ16_START( enduror_readmem )
 	{ 0x124000, 0x127fff, shared_ram_r },
 	{ 0x130000, 0x130fff, SYS16_MRA16_SPRITERAM },
 	{ 0x140002, 0x140003, sys16_coinctrl_r },
-	{ 0x140010, 0x140011, input_port_2_word_r }, // service
-	{ 0x140014, 0x140015, input_port_3_word_r }, // dip1
-	{ 0x140016, 0x140017, input_port_4_word_r }, // dip2
+	{ 0x140010, 0x140011, input_port_2_word_r }, /* service*/
+	{ 0x140014, 0x140015, input_port_3_word_r }, /* dip1*/
+	{ 0x140016, 0x140017, input_port_4_word_r }, /* dip2*/
 	{ 0x140030, 0x140031, er_io_analog_r },
 	{ 0xe00000, 0xe00001, er_reset2_r },
 MEMORY_END
@@ -663,14 +885,14 @@ PORT_END
 
 static MEMORY_READ_START( enduror_b2_sound_readmem )
 	{ 0x0000, 0x7fff, MRA_ROM },
-//	{ 0xc000, 0xc7ff, MRA_RAM },
+/*	{ 0xc000, 0xc7ff, MRA_RAM },*/
 	{ 0xf000, 0xf7ff, SegaPCM_r },
 	{ 0xf800, 0xffff, MRA_RAM },
 MEMORY_END
 
 static MEMORY_WRITE_START( enduror_b2_sound_writemem )
 	{ 0x0000, 0x7fff, MWA_ROM },
-//	{ 0xc000, 0xc7ff, MWA_RAM },
+/*	{ 0xc000, 0xc7ff, MWA_RAM },*/
 	{ 0xf000, 0xf7ff, SegaPCM_w },
 	{ 0xf800, 0xffff, MWA_RAM },
 MEMORY_END
@@ -718,8 +940,8 @@ static MACHINE_INIT( enduror ){
 	sys16_spritesystem = sys16_sprite_sharrier;
 	sys16_sprxoffset = -0xc0;
 	sys16_fgxoffset = 13;
-//	sys16_sprxoffset = -0xbb;
-//	sys16_fgxoffset = 8;
+/*	sys16_sprxoffset = -0xbb;*/
+/*	sys16_fgxoffset = 8;*/
 	sys16_textlayer_lo_min=0;
 	sys16_textlayer_lo_max=0;
 	sys16_textlayer_hi_min=0;
@@ -751,7 +973,7 @@ static void enduror_sprite_decode( void ){
 	sys16_interleave_sprite_data( 8*0x20000 );
 	generate_gr_screen(512,1024,8,0,4,0x8000);
 
-//	enduror_decode_data (rom,rom,0x10000);	// no decrypt info.
+/*	enduror_decode_data (rom,rom,0x10000);	*/ /* no decrypt info.*/
 	enduror_decode_data (rom+0x10000/2,rom+0x10000/2,0x10000);
 	enduror_decode_data2(rom+0x20000/2,rom+0x20000/2,0x10000);
 }
@@ -772,8 +994,8 @@ static void endurora_opcode_decode( void )
 	memcpy(rom+(diff+0x10000)/2,rom+0x10000/2,0x20000);
 	memcpy(rom+diff/2,rom+0x30000/2,0x10000);
 
-	// patch code to force a reset on cpu2 when starting a new game.
-	// Undoubtly wrong, but something like it is needed for the game to work
+	/* patch code to force a reset on cpu2 when starting a new game.*/
+	/* Undoubtly wrong, but something like it is needed for the game to work*/
 	rom[(0x1866 + diff)/2] = 0x4a79;
 	rom[(0x1868 + diff)/2] = 0x00e0;
 	rom[(0x186a + diff)/2] = 0x0000;
@@ -792,8 +1014,8 @@ static void endurob2_opcode_decode( void )
 	endurob2_decode_data (rom,rom+diff/2,0x10000);
 	endurob2_decode_data2(rom+0x10000/2,rom+(diff+0x10000)/2,0x10000);
 
-	// patch code to force a reset on cpu2 when starting a new game.
-	// Undoubtly wrong, but something like it is needed for the game to work
+	/* patch code to force a reset on cpu2 when starting a new game.*/
+	/* Undoubtly wrong, but something like it is needed for the game to work*/
 	rom[(0x1866 + diff)/2] = 0x4a79;
 	rom[(0x1868 + diff)/2] = 0x00e0;
 	rom[(0x186a + diff)/2] = 0x0000;
@@ -803,7 +1025,7 @@ static DRIVER_INIT( enduror )
 {
 	machine_init_sys16_onetime();
 	sys16_MaxShadowColors=NumOfShadowColors / 2;
-//	sys16_MaxShadowColors=0;
+/*	sys16_MaxShadowColors=0;*/
 
 	enduror_sprite_decode();
 }
@@ -812,7 +1034,7 @@ static DRIVER_INIT( endurobl )
 {
 	machine_init_sys16_onetime();
 	sys16_MaxShadowColors=NumOfShadowColors / 2;
-//	sys16_MaxShadowColors=0;
+/*	sys16_MaxShadowColors=0;*/
 
 	endurob_sprite_decode();
 	endurora_opcode_decode();
@@ -822,7 +1044,7 @@ static DRIVER_INIT( endurob2 )
 {
 	machine_init_sys16_onetime();
 	sys16_MaxShadowColors=NumOfShadowColors / 2;
-//	sys16_MaxShadowColors=0;
+/*	sys16_MaxShadowColors=0;*/
 
 	endurob_sprite_decode();
 	endurob2_opcode_decode();
@@ -960,8 +1182,8 @@ ROM_START( enduror )
 
 	ROM_LOAD16_BYTE( "7641.rom", 0x10000, 0x8000, CRC(2503ae7c) SHA1(27009d5b47dc207145048edfcc1ac8ffda5f0b78) )
 	ROM_LOAD16_BYTE( "7637.rom", 0x10001, 0x8000, CRC(82a27a8c) SHA1(4b182d8c23454aed7d786c9824932957319b6eff) )
-	ROM_LOAD16_BYTE( "7642.rom", 0x20000, 0x8000, CRC(1c453bea) SHA1(c6e606cdcb1690de05ef5283b48a8a61b2e0ad51) )	// enduro.a06 / .a09
-	ROM_LOAD16_BYTE( "7638.rom", 0x20001, 0x8000, CRC(70544779) SHA1(e6403edd7fc0ad5d447c25be5d7f10889aa109ff) )	// looks like encrypted versions of
+	ROM_LOAD16_BYTE( "7642.rom", 0x20000, 0x8000, CRC(1c453bea) SHA1(c6e606cdcb1690de05ef5283b48a8a61b2e0ad51) )	/* enduro.a06 / .a09*/
+	ROM_LOAD16_BYTE( "7638.rom", 0x20001, 0x8000, CRC(70544779) SHA1(e6403edd7fc0ad5d447c25be5d7f10889aa109ff) )	/* looks like encrypted versions of*/
 
 	ROM_REGION( 0x18000, REGION_GFX1, ROMREGION_DISPOSE ) /* tiles */
 	ROM_LOAD( "7644.rom", 0x00000, 0x08000, CRC(e7a4ff90) SHA1(06d18470019041e32be9a969870cd995de626cd6) )
@@ -1012,9 +1234,9 @@ ROM_START( enduror )
 	ROM_REGION( 0x10000, REGION_CPU3, 0 ) /* second 68000 CPU */
 	ROM_LOAD16_BYTE("7634.rom", 0x0000, 0x8000, CRC(3e07fd32) SHA1(7acb9e9712ecfe928c421c84dece783e75077746) )
 	ROM_LOAD16_BYTE("7635.rom", 0x0001, 0x8000, CRC(22f762ab) SHA1(70fa87da76c714db7213c42128a0b6a27644a1d4) )
-	// alternate version??
-//	ROM_LOAD16_BYTE("7634a.rom", 0x0000, 0x8000, CRC(aec83731) )
-//	ROM_LOAD16_BYTE("7635a.rom", 0x0001, 0x8000, CRC(b2fce96f) )
+	/* alternate version??*/
+/*	ROM_LOAD16_BYTE("7634a.rom", 0x0000, 0x8000, CRC(aec83731) )*/
+/*	ROM_LOAD16_BYTE("7635a.rom", 0x0001, 0x8000, CRC(b2fce96f) )*/
 
 	ROM_REGION( 0x40000, REGION_GFX3, 0 ) /* Road Graphics  (region size should be gr_bitmapwidth*256, 0 )*/
 	ROM_LOAD( "7633.rom", 0x0000, 0x8000, CRC(6f146210) SHA1(2f58f0c3563b434ed02700b9ca1545a696a5716e) )
@@ -1024,13 +1246,13 @@ ROM_START( endurobl )
 	ROM_REGION( 0x040000+0x010000+0x040000, REGION_CPU1, 0 ) /* 68000 code + space for RAM + space for decrypted opcodes */
 	ROM_LOAD16_BYTE( "7.13j", 0x030000, 0x08000, CRC(f1d6b4b7) SHA1(32bd966191cbb36d1e60ed1a06d4caa023dd6b88) )
 	ROM_CONTINUE (            0x000000, 0x08000 )
-	ROM_LOAD16_BYTE( "4.13h", 0x030001, 0x08000, CRC(43bff873) SHA1(04e906c1965a6211fb8e13987db52f1f99cc0203) )				// rom de-coded
-	ROM_CONTINUE (            0x000001, 0x08000 )		// data de-coded
+	ROM_LOAD16_BYTE( "4.13h", 0x030001, 0x08000, CRC(43bff873) SHA1(04e906c1965a6211fb8e13987db52f1f99cc0203) )				/* rom de-coded*/
+	ROM_CONTINUE (            0x000001, 0x08000 )		/* data de-coded*/
 
 	ROM_LOAD16_BYTE( "8.14j", 0x010000, 0x08000, CRC(2153154a) SHA1(145d8ed59812d26ca412a01ae77cd7872adaba5a) )
 	ROM_LOAD16_BYTE( "5.14h", 0x010001, 0x08000, CRC(0a97992c) SHA1(7a6fc8c575637107ed07a30f6f0f8cb8877cbb43) )
-	ROM_LOAD16_BYTE( "9.15j", 0x020000, 0x08000, CRC(db3bff1c) SHA1(343ed27a690800683cdd5128dcdb28c7b45288a3) )	// one byte difference from
-	ROM_LOAD16_BYTE( "6.15h", 0x020001, 0x08000, CRC(54b1885a) SHA1(f53d906390e5414e73c4cdcbc102d3cb3e719e67) )	// enduro.a06 / enduro.a09
+	ROM_LOAD16_BYTE( "9.15j", 0x020000, 0x08000, CRC(db3bff1c) SHA1(343ed27a690800683cdd5128dcdb28c7b45288a3) )	/* one byte difference from*/
+	ROM_LOAD16_BYTE( "6.15h", 0x020001, 0x08000, CRC(54b1885a) SHA1(f53d906390e5414e73c4cdcbc102d3cb3e719e67) )	/* enduro.a06 / enduro.a09*/
 
 	ROM_REGION( 0x18000, REGION_GFX1, ROMREGION_DISPOSE ) /* tiles */
 	ROM_LOAD( "7644.rom", 0x00000, 0x08000, CRC(e7a4ff90) SHA1(06d18470019041e32be9a969870cd995de626cd6) )
@@ -1250,9 +1472,9 @@ INPUT_PORTS_START( enduror )
 	PORT_START	/* handle right left */
 		PORT_ANALOG( 0xff, 0x7f, IPT_AD_STICK_X | IPF_REVERSE | IPF_CENTER, 100, 4, 0x0, 0xff )
 	PORT_START	/* Fake Buttons */
-		PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 )	// accel
-		PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2 )	// brake
-		PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )	// wheelie
+		PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON1 )	/* accel*/
+		PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON2 )	/* brake*/
+		PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_JOYSTICK_DOWN )	/* wheelie*/
 	PORT_START
 		PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_COIN1 )
 		PORT_BIT( 0x02, IP_ACTIVE_LOW, IPT_COIN2 )
@@ -1285,8 +1507,8 @@ INPUT_PORTS_START( enduror )
 		PORT_DIPNAME( 0x80, 0x00, DEF_STR( Demo_Sounds ) )
 		PORT_DIPSETTING(    0x80, DEF_STR( Off ) )
 		PORT_DIPSETTING(    0x00, DEF_STR( On ) )
-	//PORT_START	/* Y */
-	//PORT_ANALOG( 0xff, 0x0, IPT_AD_STICK_Y | IPF_CENTER , 100, 8, 0x0, 0xff )
+	/*PORT_START	 // Y /*/
+	/*PORT_ANALOG( 0xff, 0x0, IPT_AD_STICK_Y | IPF_CENTER , 100, 8, 0x0, 0xff )*/
 INPUT_PORTS_END
 
 INPUT_PORTS_START( sharrier )


### PR DESCRIPTION
Fix up the background and road graphical layers game now playable

MAME WIP

15th March 2004: Charles MacDonald made various Hang-On fixes: Fixed sprite, tile and shared RAM (2nd 68000) size in hangon - RAM test works, fixed visibility of 2nd 68000 ROM to 1st 68000, passes ROM test, fixed access to road RAM and shared RAM by both CPUs - road layer works again and added proper emulation of the I/O hardware in hangon: Cleaned up input management, now entering test mode does not crash MAME, there are no specific control hacks for the name entry screen, and the ROM patches are no longer needed.