### PR TITLE
Fix Butterfly Power Up In Super Space Invaders 91

### DIFF
--- a/src/drivers/taito_f2.c
+++ b/src/drivers/taito_f2.c
@@ -4901,7 +4901,7 @@ static MACHINE_DRIVER_START( ssi )
 
 	/* video hardware */
 	MDRV_VIDEO_START(taitof2_ssi)
-	MDRV_VIDEO_EOF(taitof2_partial_buffer_delayed)
+	MDRV_VIDEO_EOF(taitof2_partial_buffer_delayed_thundfox)	/* buffer_delayed_thundfox instead of buffer_delayed fixes the butterfly powerup */
 	MDRV_VIDEO_UPDATE(ssi)
 MACHINE_DRIVER_END
 


### PR DESCRIPTION
MAME WIP

0.102u5: Nicola Salmoria fixed butterfly wings do not work properly, when you get the 'Freeze Time' bonus.