### PR TITLE
Fix for bad bg colours at various points all through the game

### DIFF
--- a/src/drivers/dynduke.c
+++ b/src/drivers/dynduke.c
@@ -197,9 +197,12 @@ static struct GfxLayout spritelayout =
 static struct GfxLayout bg_layout =
 {
 	16,16,
-	0x2000,
-	5,	/* actually 4, 5th bit is transparency */
-	{ 0x100000*8+4, 0x80000*8+4,0x80000*8,4,0 },
+	RGN_FRAC(1,3),
+	6,
+	{ RGN_FRAC(2,3)+4, RGN_FRAC(2,3)+0,
+	  RGN_FRAC(1,3)+4, RGN_FRAC(1,3)+0,
+	                4,               0 },
+
 	{
 		0,1,2,3,8,9,10,11,
 		256+0,256+1,256+2,256+3,256+8,256+9,256+10,256+11
@@ -230,10 +233,10 @@ static struct GfxLayout fg_layout =
 
 static struct GfxDecodeInfo dynduke_gfxdecodeinfo[] =
 {
-	{ REGION_GFX1, 0, &charlayout,   1280, 16 },
-	{ REGION_GFX2, 0, &bg_layout,    2048, 32 }, /* Really 0 */
-	{ REGION_GFX3, 0, &fg_layout,     512, 16 },
-	{ REGION_GFX4, 0, &spritelayout,  768, 32 },
+	{ REGION_GFX1, 0, &charlayout,   0x500, 16 },
+	{ REGION_GFX2, 0, &bg_layout,    0x000, 128 },
+	{ REGION_GFX3, 0, &fg_layout,    0x200, 16 },
+	{ REGION_GFX4, 0, &spritelayout, 0x300, 32 },
 	{ -1 } /* end of array */
 };
 
@@ -276,7 +279,7 @@ static MACHINE_DRIVER_START( dynduke )
 	MDRV_SCREEN_SIZE(32*8, 32*8)
 	MDRV_VISIBLE_AREA(0*8, 32*8-1, 2*8, 30*8-1)
 	MDRV_GFXDECODE(dynduke_gfxdecodeinfo)
-	MDRV_PALETTE_LENGTH(2048+1024)	/* 2048 real palette, 1024 for transparency kludge */
+	MDRV_PALETTE_LENGTH(2048)
 
 	MDRV_VIDEO_START(dynduke)
 	MDRV_VIDEO_EOF(dynduke)


### PR DESCRIPTION
MAME WIP

0.119u3: David Haywood fixed colors in Dynamite Duke. Changed palettesize from 3072 to 2048 colors.
30th September 2007: David Haywood - I've hopefully fixed the colour problems from the first boss and beyond in Dynamite Duke. Note, the background is now correct in shots 3 / 4 onwards.