### PR TITLE
Turbo Outrun

### DIFF
--- a/src/drivers/outrun.c
+++ b/src/drivers/outrun.c
@@ -389,7 +389,7 @@ ROM_END
 
 // Outrun hardware
 ROM_START( outrun )
-	ROM_REGION( 0x040000, REGION_CPU1, 0 ) /* 68000 code */
+	ROM_REGION( 0x060000, REGION_CPU1, 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE( "10380a", 0x000000, 0x10000, CRC(434fadbc) SHA1(83c861d331e69ef4f2452c313ae4b5ea9d8b7948) )
 	ROM_LOAD16_BYTE( "10382a", 0x000001, 0x10000, CRC(1ddcc04e) SHA1(945d207d8d602d7fdb6d25f6b93c9c0b995e8d5a) )
 	ROM_LOAD16_BYTE( "10381a", 0x020000, 0x10000, CRC(be8c412b) SHA1(bf3ff05bbf81bdd44567f3b9bb4919ed4a499624) )
@@ -436,7 +436,7 @@ ROM_START( outrun )
 ROM_END
 
 ROM_START( outruna )
-	ROM_REGION( 0x040000, REGION_CPU1, 0 ) /* 68000 code */
+	ROM_REGION( 0x060000, REGION_CPU1, 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE( "10380b", 0x000000, 0x10000, CRC(1f6cadad) SHA1(31e870f307f44eb4f293b607123b623beee2bc3c) )
 	ROM_LOAD16_BYTE( "10382b", 0x000001, 0x10000, CRC(c4c3fa1a) SHA1(69236cf9f27691dee290c79db1fc9b5e73ea77d7) )
 	ROM_LOAD16_BYTE( "10381a", 0x020000, 0x10000, CRC(be8c412b) SHA1(bf3ff05bbf81bdd44567f3b9bb4919ed4a499624) )
@@ -484,7 +484,7 @@ ROM_END
 
 
 ROM_START( outrunb )
-	ROM_REGION( 0x040000, REGION_CPU1, 0 ) /* 68000 code */
+	ROM_REGION( 0x060000, REGION_CPU1, 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE( "orun_mn.rom", 0x000000, 0x10000, CRC(cddceea2) SHA1(34cb4ca61c941e96e585f3cd2aed79bdde67f8eb) )
 	ROM_LOAD16_BYTE( "orun_ml.rom", 0x000001, 0x10000, CRC(9cfc07d5) SHA1(b1b5992ff99e4158bb008684e694e088a4b282c6) )
 	ROM_LOAD16_BYTE( "orun_mm.rom", 0x020000, 0x10000, CRC(3092d857) SHA1(8ebfeab9217b80a7983a4f8eb7bb7d3387d791b3) )
@@ -544,11 +544,10 @@ ROM_END
 
 ROM_START( toutrun )
 	ROM_REGION( 0x100000, REGION_CPU1, 0 ) /* 68000 code */
-// custom cpu 317-0106
-	ROM_LOAD16_BYTE( "epr12397.133", 0x000000, 0x10000, CRC(e4b57d7d) SHA1(62be55356c82b38ebebcc87a5458e23300019339) )
-	ROM_LOAD16_BYTE( "epr12396.118", 0x000001, 0x10000, CRC(5e7115cb) SHA1(02c9ec91d9afb424e5045671ab0b5499181728c9) )
-	ROM_LOAD16_BYTE( "epr12399.132", 0x020000, 0x10000, CRC(62c77b1b) SHA1(004803c68cb1b3e414296ffbf50dc3b33b9ffb9a) )
-	ROM_LOAD16_BYTE( "epr12398.117", 0x020001, 0x10000, CRC(18e34520) SHA1(3f10ecb809106b82fd44fd6244d8d8e7f1c8e08d) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12513.133", 0x000000, 0x10000, CRC(a1881cea) SHA1(f04291475d603a4558ebeeeaa45b03761c9c0e68) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12512.118", 0x000001, 0x10000, CRC(5e9d788b) SHA1(189dfcdfbd20ed69d861858632b50aa97826d1a9) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12515.132", 0x020000, 0x10000, CRC(fd432e2d) SHA1(dfef4f1f8ac5f7d8e905dc95daddbfd299257aa1) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12514.117", 0x020001, 0x10000, CRC(faf00bd6) SHA1(1e35fa02826a5680926d5d3d1cc83b09d4e170bf) )
 	ROM_LOAD16_BYTE( "epr12293.131", 0x040000, 0x10000, CRC(f4321eea) SHA1(64334acc82c14bb58b7d51719f34fd81cfb9fc6b) )
 	ROM_LOAD16_BYTE( "epr12292.116", 0x040001, 0x10000, CRC(51d98af0) SHA1(6e7115706bfafb687faa23d55d4a8c8e498a4df2) )
 
@@ -558,31 +557,25 @@ ROM_START( toutrun )
 	ROM_LOAD( "opr12325.104", 0x20000, 0x10000, CRC(1405137a) SHA1(367db88d36852e35c5e839f692be5ea8c8e072d2) )
 
 	ROM_REGION( 0x100000, REGION_GFX2, 0 ) /* sprites */
-	ROM_LOAD16_BYTE( "opr12307.9",  0x00001, 0x10000, CRC(437dcf09) SHA1(0022ee4d1c3698f77271e570cef98a8a1e5c5d6a) )
-	ROM_LOAD16_BYTE( "opr12308.10", 0x00000, 0x10000, CRC(0de70cc2) SHA1(c03f8f8cda72daf64af2878bf254840ac6dd17eb) )
-	ROM_LOAD16_BYTE( "opr12309.11", 0x20001, 0x10000, CRC(deb8c242) SHA1(c05d8ced4eafae52c4795fb1471cd66f5903d1aa) )
-	ROM_LOAD16_BYTE( "opr12310.12", 0x20000, 0x10000, CRC(45cf157e) SHA1(5d0be2a374a53ea1fe0ba2bf9b2173e96de1eb51) )
-	ROM_LOAD16_BYTE( "opr12311.13", 0x40001, 0x10000, CRC(ae2bd639) SHA1(64bb60ae7e3f87fbbce00106ba65c4e6fc1af0e4) )
-	ROM_LOAD16_BYTE( "opr12312.14", 0x40000, 0x10000, CRC(626000e7) SHA1(4a7f9e76dd76a3dc56b8257149bc94be3f4f2e87) )
-	ROM_LOAD16_BYTE( "opr12313.15", 0x60001, 0x10000, CRC(52870c37) SHA1(3a6836a46d94c0f9115800d206410252a1134c57) )
-	ROM_LOAD16_BYTE( "opr12314.16", 0x60000, 0x10000, CRC(40c461ea) SHA1(7bed8f24112dc3c827fd087138fcf2700092aa59) )
-	ROM_LOAD16_BYTE( "opr12315.17", 0x80001, 0x10000, CRC(3ff9a3a3) SHA1(0d90fe2669d03bd07a0d3b05934201778e28d54c) )
-	ROM_LOAD16_BYTE( "opr12316.18", 0x80000, 0x10000, CRC(8a1e6dc8) SHA1(32f09ec504c2b6772815bad7380a2f738f11746a) )
-	ROM_LOAD16_BYTE( "opr12317.19", 0xa0001, 0x10000, CRC(77e382d4) SHA1(5b7912069a46043b7be989d82436add85497d318) )
-	ROM_LOAD16_BYTE( "opr12318.20", 0xa0000, 0x10000, CRC(d1afdea9) SHA1(813eccc88d5046992be5b5a0618d32127d16e30b) )
-	ROM_LOAD16_BYTE( "opr12320.22", 0xc0001, 0x10000, CRC(7931e446) SHA1(9f2161a689ebad61f6653942e23d9c2bc6170d4a) )
-	ROM_LOAD16_BYTE( "opr12321.23", 0xc0000, 0x10000, CRC(830bacd4) SHA1(5a4816969437ee1edca5845006c0b8e9ba365491) )
-	ROM_LOAD16_BYTE( "opr12322.24", 0xe0001, 0x10000, CRC(8b812492) SHA1(bf1f9e059c093c0991c7caf1b01c739ed54b8357) )
-	ROM_LOAD16_BYTE( "opr12319.25", 0xe0000, 0x10000, CRC(df23baf9) SHA1(f9611391bb3b3b92203fa9f6dd461e3a6e863622) )
+	ROM_LOAD( "mpr12336.9",   0x00000, 0x20000, CRC(dda465c7) SHA1(83acc12a387b004986f084f25964c15a9f88a41a) )
+	ROM_LOAD( "mpr12337.10",  0x40000, 0x20000, CRC(828233d1) SHA1(d73a200af4245d590e1fd3ac436723f99cc50452) )
+	ROM_LOAD( "mpr12338.11",  0x80000, 0x20000, CRC(46b4b5f4) SHA1(afeb2e5ac6792edafe7328993fe8dfcd4bce1924) )
+	ROM_LOAD( "mpr12339.12",  0xc0000, 0x20000, CRC(0d7e3bab) SHA1(fdb603df55785ded593daf591ddd90f8f24e0d47) )
+	ROM_LOAD( "mpr12364.13",  0x20000, 0x20000, CRC(a4b83e65) SHA1(966d8c163cef0842abff54e1dba3f15248e73f68) )
+	ROM_LOAD( "mpr12365.14",  0x60000, 0x20000, CRC(4a80b2a9) SHA1(14b4fe71e102622a73c8dc0dbd0013cbbe6fcf9d) )
+	ROM_LOAD( "mpr12366.15",  0xa0000, 0x20000, CRC(385cb3ab) SHA1(fec6d80d488bfe26524fa3a48b195a45a073e481) )
+	ROM_LOAD( "mpr12367.16",  0xe0000, 0x20000, CRC(4930254a) SHA1(00f24be3bf02b143fa554f4d32e283bdac79af6a) )
 
-	ROM_REGION( 0x70000, REGION_CPU2, 0 ) /* sound CPU */
+	ROM_REGION( 0x10000, REGION_CPU2, 0 ) /* sound CPU */
 	ROM_LOAD( "epr12300.88",	0x00000, 0x10000, CRC(e8ff7011) SHA1(6eaf3aea507007ea31d507ed7825d905f4b8e7ab) )
-	ROM_LOAD( "opr12301.66",    0x10000, 0x10000, CRC(6e78ad15) SHA1(c31ddf434b459cd1a381d2a028beabddd4ed10d2) )
-	ROM_LOAD( "opr12302.67",    0x20000, 0x10000, CRC(e72928af) SHA1(40e0b178958cfe97c097fe9d82b5de54bc27a29f) )
-	ROM_LOAD( "opr12303.68",    0x30000, 0x10000, CRC(8384205c) SHA1(c1f9d52bc587eab5a97867198e9aa7c19e973429) )
-	ROM_LOAD( "opr12304.69",    0x40000, 0x10000, CRC(e1762ac3) SHA1(855f06c082a17d90857e6efa3cf95b0eda0e634d) )
-	ROM_LOAD( "opr12305.70",    0x50000, 0x10000, CRC(ba9ce677) SHA1(056781f92450c902e1d279a02bda28337815cba9) )
-	ROM_LOAD( "opr12306.71",    0x60000, 0x10000, CRC(e49249fd) SHA1(ff36e4dba4e9d3d354e3dd528edeb50ad9c18ee4) )
+
+	ROM_REGION( 0x100000, REGION_SOUND1, 0 ) /* sound CPU */
+	ROM_LOAD( "opr12301.66",    0x00000, 0x10000, CRC(6e78ad15) SHA1(c31ddf434b459cd1a381d2a028beabddd4ed10d2) )
+	ROM_LOAD( "opr12302.67",    0x10000, 0x10000, CRC(e72928af) SHA1(40e0b178958cfe97c097fe9d82b5de54bc27a29f) )
+	ROM_LOAD( "opr12303.68",    0x20000, 0x10000, CRC(8384205c) SHA1(c1f9d52bc587eab5a97867198e9aa7c19e973429) )
+	ROM_LOAD( "opr12304.69",    0x30000, 0x10000, CRC(e1762ac3) SHA1(855f06c082a17d90857e6efa3cf95b0eda0e634d) )
+	ROM_LOAD( "opr12305.70",    0x40000, 0x10000, CRC(ba9ce677) SHA1(056781f92450c902e1d279a02bda28337815cba9) )
+	ROM_LOAD( "opr12306.71",    0x50000, 0x10000, CRC(e49249fd) SHA1(ff36e4dba4e9d3d354e3dd528edeb50ad9c18ee4) )
 
 	ROM_REGION( 0x100000, REGION_CPU3, 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE( "opr12295.76", 0x000000, 0x10000, CRC(d43a3a84) SHA1(362c98f62c205b6b40b7e8a4ba107745b547b984) )
@@ -590,18 +583,17 @@ ROM_START( toutrun )
 	ROM_LOAD16_BYTE( "opr12297.75", 0x020000, 0x10000, CRC(1d9b5677) SHA1(fb6e33acc43fbc7a8d7ac44045439ecdf794fdeb) )
 	ROM_LOAD16_BYTE( "opr12296.57", 0x020001, 0x10000, CRC(0a513671) SHA1(4c13ca3a6f0aa9d06ed80798b466cca0c966a265) )
 
-	ROM_REGION( 0x40000, REGION_GFX3, 0 ) /* road */
+	ROM_REGION( 0x80000, REGION_GFX3, 0 ) /* Road Graphics  (region size should be gr_bitmapwidth*256, 0 )*/
 	ROM_LOAD( "epr12298.11", 0x0, 0x08000, CRC(fc9bc41b) SHA1(9af73e096253cf2c4f283f227530110a4b37fcee) )
 ROM_END
 
 
-ROM_START( toutruna )
+ROM_START( toutrun3 )
 	ROM_REGION( 0x100000, REGION_CPU1, 0 ) /* 68000 code */
-// custom cpu 317-0106
-	ROM_LOAD16_BYTE( "epr12410.133", 0x000000, 0x10000, CRC(aa74f3e9) SHA1(2daf6b17317542063c0a40beea5b45c797192591) )
-	ROM_LOAD16_BYTE( "epr12409.118", 0x000001, 0x10000, CRC(c11c8ef7) SHA1(4c1c5100d7fd728642d58e4bf45fba48695841e3) )
-	ROM_LOAD16_BYTE( "epr12412.132", 0x020000, 0x10000, CRC(b0534647) SHA1(40f2260ff0d0ac662d118cc7280bb26006ee75e9) )
-	ROM_LOAD16_BYTE( "epr12411.117", 0x020001, 0x10000, CRC(12bb0d83) SHA1(4aa1b724b2a7258fff7aa1971582950b3163c0db) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12410.133", 0x000000, 0x10000, CRC(8e716903) SHA1(6a5c168097623c97358fc5dd8e205cf61932d3e9) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12409.118", 0x000001, 0x10000, CRC(675d4dd8) SHA1(e74dc3c21196baac94c41e844b2a9054842ae863) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12412.132", 0x020000, 0x10000, CRC(89da477c) SHA1(f854a48d96539d87d2417d936bd6bec1b7ea32fd) )
+	ROM_LOAD16_BYTE( "bootleg_epr-12411.117", 0x020001, 0x10000, CRC(285837ee) SHA1(186fff13cd50af504c0dc0296af96dfa24d0d32e) )
 	ROM_LOAD16_BYTE( "epr12293.131", 0x040000, 0x10000, CRC(f4321eea) SHA1(64334acc82c14bb58b7d51719f34fd81cfb9fc6b) )
 	ROM_LOAD16_BYTE( "epr12292.116", 0x040001, 0x10000, CRC(51d98af0) SHA1(6e7115706bfafb687faa23d55d4a8c8e498a4df2) )
 
@@ -610,32 +602,34 @@ ROM_START( toutruna )
 	ROM_LOAD( "opr12324.103", 0x10000, 0x10000, CRC(24607a55) SHA1(69033f2281cd42e88233c23d809b73607fe54853) )
 	ROM_LOAD( "opr12325.104", 0x20000, 0x10000, CRC(1405137a) SHA1(367db88d36852e35c5e839f692be5ea8c8e072d2) )
 
-	ROM_REGION( 0x100000, REGION_GFX2, 0 ) /* sprites */
-	ROM_LOAD16_BYTE( "opr12307.9",  0x00001, 0x10000, CRC(437dcf09) SHA1(0022ee4d1c3698f77271e570cef98a8a1e5c5d6a) )
-	ROM_LOAD16_BYTE( "opr12308.10", 0x00000, 0x10000, CRC(0de70cc2) SHA1(c03f8f8cda72daf64af2878bf254840ac6dd17eb) )
-	ROM_LOAD16_BYTE( "opr12309.11", 0x20001, 0x10000, CRC(deb8c242) SHA1(c05d8ced4eafae52c4795fb1471cd66f5903d1aa) )
-	ROM_LOAD16_BYTE( "opr12310.12", 0x20000, 0x10000, CRC(45cf157e) SHA1(5d0be2a374a53ea1fe0ba2bf9b2173e96de1eb51) )
-	ROM_LOAD16_BYTE( "opr12311.13", 0x40001, 0x10000, CRC(ae2bd639) SHA1(64bb60ae7e3f87fbbce00106ba65c4e6fc1af0e4) )
-	ROM_LOAD16_BYTE( "opr12312.14", 0x40000, 0x10000, CRC(626000e7) SHA1(4a7f9e76dd76a3dc56b8257149bc94be3f4f2e87) )
-	ROM_LOAD16_BYTE( "opr12313.15", 0x60001, 0x10000, CRC(52870c37) SHA1(3a6836a46d94c0f9115800d206410252a1134c57) )
-	ROM_LOAD16_BYTE( "opr12314.16", 0x60000, 0x10000, CRC(40c461ea) SHA1(7bed8f24112dc3c827fd087138fcf2700092aa59) )
-	ROM_LOAD16_BYTE( "opr12315.17", 0x80001, 0x10000, CRC(3ff9a3a3) SHA1(0d90fe2669d03bd07a0d3b05934201778e28d54c) )
-	ROM_LOAD16_BYTE( "opr12316.18", 0x80000, 0x10000, CRC(8a1e6dc8) SHA1(32f09ec504c2b6772815bad7380a2f738f11746a) )
-	ROM_LOAD16_BYTE( "opr12317.19", 0xa0001, 0x10000, CRC(77e382d4) SHA1(5b7912069a46043b7be989d82436add85497d318) )
-	ROM_LOAD16_BYTE( "opr12318.20", 0xa0000, 0x10000, CRC(d1afdea9) SHA1(813eccc88d5046992be5b5a0618d32127d16e30b) )
-	ROM_LOAD16_BYTE( "opr12320.22", 0xc0001, 0x10000, CRC(7931e446) SHA1(9f2161a689ebad61f6653942e23d9c2bc6170d4a) )
-	ROM_LOAD16_BYTE( "opr12321.23", 0xc0000, 0x10000, CRC(830bacd4) SHA1(5a4816969437ee1edca5845006c0b8e9ba365491) )
-	ROM_LOAD16_BYTE( "opr12322.24", 0xe0001, 0x10000, CRC(8b812492) SHA1(bf1f9e059c093c0991c7caf1b01c739ed54b8357) )
-	ROM_LOAD16_BYTE( "opr12319.25", 0xe0000, 0x10000, CRC(df23baf9) SHA1(f9611391bb3b3b92203fa9f6dd461e3a6e863622) )
+	ROM_REGION( 0x100000, REGION_GFX2, 0 ) /* sprites */	
+	ROM_LOAD( "opr12307.9",  0x00000, 0x10000, CRC(437dcf09) SHA1(0022ee4d1c3698f77271e570cef98a8a1e5c5d6a) )
+	ROM_LOAD( "opr12308.10", 0x40000, 0x10000, CRC(0de70cc2) SHA1(c03f8f8cda72daf64af2878bf254840ac6dd17eb) )
+	ROM_LOAD( "opr12309.11", 0x80000, 0x10000, CRC(deb8c242) SHA1(c05d8ced4eafae52c4795fb1471cd66f5903d1aa) )
+	ROM_LOAD( "opr12310.12", 0xc0000, 0x10000, CRC(45cf157e) SHA1(5d0be2a374a53ea1fe0ba2bf9b2173e96de1eb51) )
+	ROM_LOAD( "opr12311.13", 0x10000, 0x10000, CRC(ae2bd639) SHA1(64bb60ae7e3f87fbbce00106ba65c4e6fc1af0e4) )
+	ROM_LOAD( "opr12312.14", 0x50000, 0x10000, CRC(626000e7) SHA1(4a7f9e76dd76a3dc56b8257149bc94be3f4f2e87) )
+	ROM_LOAD( "opr12313.15", 0x90000, 0x10000, CRC(52870c37) SHA1(3a6836a46d94c0f9115800d206410252a1134c57) )
+	ROM_LOAD( "opr12314.16", 0xd0000, 0x10000, CRC(40c461ea) SHA1(7bed8f24112dc3c827fd087138fcf2700092aa59) )
+	ROM_LOAD( "opr12315.17", 0x20000, 0x10000, CRC(3ff9a3a3) SHA1(0d90fe2669d03bd07a0d3b05934201778e28d54c) )
+	ROM_LOAD( "opr12316.18", 0x60000, 0x10000, CRC(8a1e6dc8) SHA1(32f09ec504c2b6772815bad7380a2f738f11746a) )
+	ROM_LOAD( "opr12317.19", 0xa0000, 0x10000, CRC(77e382d4) SHA1(5b7912069a46043b7be989d82436add85497d318) )
+	ROM_LOAD( "opr12318.20", 0xe0000, 0x10000, CRC(d1afdea9) SHA1(813eccc88d5046992be5b5a0618d32127d16e30b) )
+	ROM_LOAD( "opr12319.25", 0x30000, 0x10000, CRC(df23baf9) SHA1(f9611391bb3b3b92203fa9f6dd461e3a6e863622) )
+	ROM_LOAD( "opr12320.22", 0x70000, 0x10000, CRC(7931e446) SHA1(9f2161a689ebad61f6653942e23d9c2bc6170d4a) )
+	ROM_LOAD( "opr12321.23", 0xb0000, 0x10000, CRC(830bacd4) SHA1(5a4816969437ee1edca5845006c0b8e9ba365491) )
+	ROM_LOAD( "opr12322.24", 0xf0000, 0x10000, CRC(8b812492) SHA1(bf1f9e059c093c0991c7caf1b01c739ed54b8357) )
 
-	ROM_REGION( 0x70000, REGION_CPU2, 0 ) /* sound CPU */
+	ROM_REGION( 0x10000, REGION_CPU2, 0 ) /* sound CPU */
 	ROM_LOAD( "epr12300.88",	0x00000, 0x10000, CRC(e8ff7011) SHA1(6eaf3aea507007ea31d507ed7825d905f4b8e7ab) )
-	ROM_LOAD( "opr12301.66",    0x10000, 0x10000, CRC(6e78ad15) SHA1(c31ddf434b459cd1a381d2a028beabddd4ed10d2) )
-	ROM_LOAD( "opr12302.67",    0x20000, 0x10000, CRC(e72928af) SHA1(40e0b178958cfe97c097fe9d82b5de54bc27a29f) )
-	ROM_LOAD( "opr12303.68",    0x30000, 0x10000, CRC(8384205c) SHA1(c1f9d52bc587eab5a97867198e9aa7c19e973429) )
-	ROM_LOAD( "opr12304.69",    0x40000, 0x10000, CRC(e1762ac3) SHA1(855f06c082a17d90857e6efa3cf95b0eda0e634d) )
-	ROM_LOAD( "opr12305.70",    0x50000, 0x10000, CRC(ba9ce677) SHA1(056781f92450c902e1d279a02bda28337815cba9) )
-	ROM_LOAD( "opr12306.71",    0x60000, 0x10000, CRC(e49249fd) SHA1(ff36e4dba4e9d3d354e3dd528edeb50ad9c18ee4) )
+
+	ROM_REGION( 0x100000, REGION_SOUND1, 0 ) /* sound CPU */
+	ROM_LOAD( "opr12301.66",    0x00000, 0x10000, CRC(6e78ad15) SHA1(c31ddf434b459cd1a381d2a028beabddd4ed10d2) )
+	ROM_LOAD( "opr12302.67",    0x10000, 0x10000, CRC(e72928af) SHA1(40e0b178958cfe97c097fe9d82b5de54bc27a29f) )
+	ROM_LOAD( "opr12303.68",    0x20000, 0x10000, CRC(8384205c) SHA1(c1f9d52bc587eab5a97867198e9aa7c19e973429) )
+	ROM_LOAD( "opr12304.69",    0x30000, 0x10000, CRC(e1762ac3) SHA1(855f06c082a17d90857e6efa3cf95b0eda0e634d) )
+	ROM_LOAD( "opr12305.70",    0x40000, 0x10000, CRC(ba9ce677) SHA1(056781f92450c902e1d279a02bda28337815cba9) )
+	ROM_LOAD( "opr12306.71",    0x50000, 0x10000, CRC(e49249fd) SHA1(ff36e4dba4e9d3d354e3dd528edeb50ad9c18ee4) )
 
 	ROM_REGION( 0x100000, REGION_CPU3, 0 ) /* 68000 code */
 	ROM_LOAD16_BYTE( "opr12295.76", 0x000000, 0x10000, CRC(d43a3a84) SHA1(362c98f62c205b6b40b7e8a4ba107745b547b984) )
@@ -643,9 +637,10 @@ ROM_START( toutruna )
 	ROM_LOAD16_BYTE( "opr12297.75", 0x020000, 0x10000, CRC(1d9b5677) SHA1(fb6e33acc43fbc7a8d7ac44045439ecdf794fdeb) )
 	ROM_LOAD16_BYTE( "opr12296.57", 0x020001, 0x10000, CRC(0a513671) SHA1(4c13ca3a6f0aa9d06ed80798b466cca0c966a265) )
 
-	ROM_REGION( 0x40000, REGION_GFX3, 0 ) /* road */
+    ROM_REGION( 0x80000, REGION_GFX3, 0 ) /* Road Graphics  (region size should be gr_bitmapwidth*256, 0 )*/
 	ROM_LOAD( "epr12298.11", 0x0, 0x08000, CRC(fc9bc41b) SHA1(9af73e096253cf2c4f283f227530110a4b37fcee) )
 ROM_END
+
 
 /***************************************************************************/
 
@@ -879,16 +874,6 @@ static WRITE16_HANDLER( outrun_sound_write_w )
 		sound_shared_ram[0]=data&0xff;
 }
 
-static WRITE16_HANDLER( outrun_ctrl1_w )
-{
-	if( ACCESSING_LSB ){
-		sys16_refreshenable = data & 0x20;
-		/* bit 0 always 1? */
-		/* bits 2-3 continuously change: 00-01-10-11; this is the same that
-		   gets written to 140030 so is probably input related */
-	}
-}
-
 static WRITE16_HANDLER( outrun_ctrl2_w )
 {
 	if( ACCESSING_LSB ){
@@ -898,9 +883,40 @@ static WRITE16_HANDLER( outrun_ctrl2_w )
 		coin_counter_w(0,data & 0x10);
 	}
 }
+static unsigned char ctrl1;
+
+static WRITE16_HANDLER( outrun_ctrl1_w )
+{
+	/* sound be sound cpu reset, not 2nd 68k cpu? */
+#if 0
+	if(ACCESSING_LSB) {
+		int changed = data ^ ctrl1;
+		ctrl1 = data;
+		if(changed & 1) {
+			if(data & 1) {
+				cpu_set_halt_line(2, CLEAR_LINE);
+				cpu_set_reset_line(2, PULSE_LINE);
+			} else
+				cpu_set_halt_line(2, ASSERT_LINE);
+		}
+
+//		sys16_kill_set(data & 0x20);
+
+		/* bit 0 always 1? */
+		/* bits 2-3 continuously change: 00-01-10-11; this is the same that
+		   gets written to 140030 so is probably input related */
+	}
+#endif
+}
+
+static void outrun_reset(void)
+{
+       cpu_set_reset_line(2, PULSE_LINE);
+	   cpu_set_halt_line(2, CLEAR_LINE);
+}
 
 static MEMORY_READ16_START( outrun_readmem )
-	{ 0x000000, 0x03ffff, MRA16_ROM },
+	{ 0x000000, 0x05ffff, MRA16_ROM },
 	{ 0x060900, 0x060907, sound_shared_ram_r },		//???
 	{ 0x060000, 0x067fff, SYS16_MRA16_EXTRAM2 },
 
@@ -921,7 +937,7 @@ static MEMORY_READ16_START( outrun_readmem )
 MEMORY_END
 
 static MEMORY_WRITE16_START( outrun_writemem )
-	{ 0x000000, 0x03ffff, MWA16_ROM },
+	{ 0x000000, 0x05ffff, MWA16_ROM },
 	{ 0x060900, 0x060907, sound_shared_ram_w },		//???
 	{ 0x060000, 0x067fff, SYS16_MWA16_EXTRAM2 },
 	{ 0x100000, 0x10ffff, SYS16_MWA16_TILERAM },
@@ -962,7 +978,7 @@ static MEMORY_WRITE_START( outrun_sound_writemem )
 	{ 0x0000, 0x7fff, MWA_ROM },
 	{ 0xf000, 0xf0ff, SegaPCM_w },
 	{ 0xf100, 0xf7ff, MWA_NOP },
-	{ 0xf800, 0xf807, sound2_shared_ram_w,&sound_shared_ram },
+	{ 0xf800, 0xf807, sound2_shared_ram_w, &sound_shared_ram },
 	{ 0xf808, 0xffff, MWA_RAM },
 MEMORY_END
 
@@ -989,30 +1005,22 @@ static MACHINE_INIT( outrun ){
 	sys16_textlayer_hi_min=0;
 	sys16_textlayer_hi_max=0xff;
 	sys16_sprxoffset = -0xc0;
+	ctrl1 = 0x20;
 
-// hack: cpu 0 reset opcode resets cpu 2
-	sys16_patch_code(0x7d44,0x4a);
-	sys16_patch_code(0x7d45,0x79);
-	sys16_patch_code(0x7d46,0x00);
-	sys16_patch_code(0x7d47,0xe0);
-	sys16_patch_code(0x7d48,0x00);
-	sys16_patch_code(0x7d49,0x00);
+// *forced sound cmd (eww)
+	if (!strcmp(Machine->gamedrv->name,"outrun")) sys16_patch_code( 0x55ed, 0x00);
+	if (!strcmp(Machine->gamedrv->name,"outruna")) sys16_patch_code( 0x5661, 0x00);
+	if (!strcmp(Machine->gamedrv->name,"outrunb")) sys16_patch_code( 0x5661, 0x00);
 
-// *forced sound cmd
-	sys16_patch_code( 0x55ed, 0x00);
+    cpu_set_m68k_reset(0, outrun_reset);
 
-// rogue tile on music selection screen
-//	sys16_patch_code( 0x38545, 0x80);
-
-// *freeze time
-//	sys16_patch_code( 0xb6b6, 0x4e);
-//	sys16_patch_code( 0xb6b7, 0x71);
 
 	sys16_update_proc = outrun_update_proc;
 
 	sys16_gr_ver = &sys16_extraram[0];
 	sys16_gr_hor = sys16_gr_ver+0x400/2;
 	sys16_gr_flip= sys16_gr_ver+0xc00/2;
+
 
 	sys16_gr_palette= 0xf00 / 2;
 	sys16_gr_palette_default = 0x800 /2;
@@ -1026,63 +1034,25 @@ static MACHINE_INIT( outrun ){
 	sys16_gr_colorflip[1][3]=0x00 / 2;
 
 	sys16_gr_second_road = &sys16_extraram[0x8000];
+	
+	cpu_set_halt_line(2, ASSERT_LINE);
 }
 
-static MACHINE_INIT( outruna ){
-	static int bank[8] = {
-		7,0,1,2,
-		3,4,5,6
-	};
-	sys16_obj_bank = bank;
-	sys16_spritesystem = sys16_sprite_outrun;
-	sys16_textlayer_lo_min=0;
-	sys16_textlayer_lo_max=0;
-	sys16_textlayer_hi_min=0;
-	sys16_textlayer_hi_max=0xff;
-
-// cpu 0 reset opcode resets cpu 2
-	sys16_patch_code(0x7db8,0x4a);
-	sys16_patch_code(0x7db9,0x79);
-	sys16_patch_code(0x7dba,0x00);
-	sys16_patch_code(0x7dbb,0xe0);
-	sys16_patch_code(0x7dbc,0x00);
-	sys16_patch_code(0x7dbd,0x00);
-
-// *forced sound cmd
-	sys16_patch_code( 0x5661, 0x00);
-
-// rogue tile on music selection screen
-//	sys16_patch_code( 0x38455, 0x80);
-
-// *freeze time
-//	sys16_patch_code( 0xb6b6, 0x4e);
-//	sys16_patch_code( 0xb6b7, 0x71);
-
-	sys16_update_proc = outrun_update_proc;
-
-	sys16_gr_ver = &sys16_extraram[0];
-	sys16_gr_hor = sys16_gr_ver+0x400/2;
-	sys16_gr_flip= sys16_gr_ver+0xc00/2;
-
-	sys16_gr_palette= 0xf00 / 2;
-	sys16_gr_palette_default = 0x800 /2;
-	sys16_gr_colorflip[0][0]=0x08 / 2;
-	sys16_gr_colorflip[0][1]=0x04 / 2;
-	sys16_gr_colorflip[0][2]=0x00 / 2;
-	sys16_gr_colorflip[0][3]=0x00 / 2;
-	sys16_gr_colorflip[1][0]=0x0a / 2;
-	sys16_gr_colorflip[1][1]=0x06 / 2;
-	sys16_gr_colorflip[1][2]=0x02 / 2;
-	sys16_gr_colorflip[1][3]=0x00 / 2;
-
-	sys16_gr_second_road = &sys16_extraram[0x10000];
-}
 
 static DRIVER_INIT( outrun )
 {
 	machine_init_sys16_onetime();
 	sys16_interleave_sprite_data( 0x100000 );
 	generate_gr_screen(512,2048,0,0,3,0x8000);
+
+}
+
+static DRIVER_INIT( toutrun )
+{
+	machine_init_sys16_onetime();
+	sys16_interleave_sprite_data( 0x100000 );
+	generate_gr_screen(512,2048,0,0,0,0x8000); /* fixes road 2 */
+
 }
 
 static DRIVER_INIT( outrunb )
@@ -1238,6 +1208,72 @@ PORT_START	/* Brake */
 
 INPUT_PORTS_END
 
+
+INPUT_PORTS_START( toutrun )
+PORT_START	/* Steering */
+	PORT_ANALOG( 0xff, 0x80, IPT_AD_STICK_X | IPF_CENTER, 100, 3, 0x48, 0xb8 )
+//	PORT_ANALOG( 0xff, 0x7f, IPT_PADDLE , 70, 3, 0x48, 0xb8 )
+
+#ifdef HANGON_DIGITAL_CONTROLS
+
+PORT_START	/* Buttons */
+	PORT_BIT( 0x01, IP_ACTIVE_HIGH, IPT_BUTTON2 )
+	PORT_BIT( 0x02, IP_ACTIVE_HIGH, IPT_BUTTON1 )
+	PORT_BIT( 0x04, IP_ACTIVE_HIGH, IPT_BUTTON3 )
+	PORT_BIT( 0x08, IP_ACTIVE_HIGH, IPT_BUTTON4 )
+
+#else
+
+PORT_START	/* Accel / Decel */
+	PORT_ANALOG( 0xff, 0x30, IPT_AD_STICK_Y | IPF_CENTER | IPF_REVERSE, 100, 16, 0x30, 0x90 )
+
+#endif
+
+PORT_START
+	PORT_BIT( 0x01, IP_ACTIVE_LOW, IPT_UNKNOWN )
+	PORT_BITX(0x02, IP_ACTIVE_LOW, IPT_SERVICE, DEF_STR( Service_Mode ), KEYCODE_F2, IP_JOY_NONE )
+	PORT_BIT( 0x04, IP_ACTIVE_LOW, IPT_SERVICE1 )
+	PORT_BIT( 0x08, IP_ACTIVE_LOW, IPT_START1 )
+//	PORT_BIT( 0x10, IP_ACTIVE_LOW, IPT_BUTTON3 )
+	PORT_BIT( 0x20, IP_ACTIVE_LOW, IPT_BUTTON5 ) // Turbo
+	PORT_BIT( 0x40, IP_ACTIVE_LOW, IPT_COIN1 )
+	PORT_BIT( 0x80, IP_ACTIVE_LOW, IPT_COIN2 )
+
+	SYS16_COINAGE
+
+PORT_START	/* DSW1 */
+	PORT_DIPNAME( 0x03, 0x02, DEF_STR( Cabinet ) )
+	PORT_DIPSETTING(    0x02, "Cockpit Conversion" )
+	PORT_DIPSETTING(    0x01, "Mini Up" )
+	PORT_DIPSETTING(    0x03, "Moving" )
+	PORT_DIPSETTING(    0x00, "Cockpit" )
+	PORT_DIPNAME( 0x04, 0x00, DEF_STR( Demo_Sounds ) )
+	PORT_DIPSETTING(    0x04, DEF_STR( Off ) )
+	PORT_DIPSETTING(    0x00, DEF_STR( On ) )
+	PORT_DIPNAME( 0x08, 0x08, "Turbo" )
+	PORT_DIPSETTING(    0x00, "Start Button" )
+	PORT_DIPSETTING(    0x08, "Use Turbo Shifter" )
+	PORT_DIPNAME( 0x30, 0x10, "Credits" )
+	PORT_DIPSETTING(    0x20, "3 to Start/2 to Continue" )
+	PORT_DIPSETTING(    0x30, "2 to Start/1 to Continue" )
+	PORT_DIPSETTING(    0x10, "1 to Start/1 to Continue" )
+	PORT_DIPSETTING(    0x00, "2 to Start/2 to Continue" )
+	PORT_DIPNAME( 0xc0, 0xc0, "Enemies" )
+	PORT_DIPSETTING(    0x80, "Easy" )
+	PORT_DIPSETTING(    0xc0, "Normal" )
+	PORT_DIPSETTING(    0x40, "Hard" )
+	PORT_DIPSETTING(    0x00, "Hardest" )
+
+
+#ifndef HANGON_DIGITAL_CONTROLS
+
+PORT_START	/* Brake */
+	PORT_ANALOG( 0xff, 0x30, IPT_AD_STICK_Y | IPF_PLAYER2 | IPF_CENTER | IPF_REVERSE, 100, 16, 0x30, 0x90 )
+
+#endif
+
+INPUT_PORTS_END
+
 /***************************************************************************/
 static INTERRUPT_GEN( or_interrupt ){
 	int intleft=cpu_getiloops();
@@ -1294,7 +1330,7 @@ static MACHINE_DRIVER_START( outrun )
 	outrun_start_counter = 0;
 MACHINE_DRIVER_END
 
-
+#if 0
 static MACHINE_DRIVER_START( outruna )
 
 	/* basic machine hardware */
@@ -1302,7 +1338,45 @@ static MACHINE_DRIVER_START( outruna )
 
 	MDRV_MACHINE_INIT(outruna)
 MACHINE_DRIVER_END
+#endif
 
+static MACHINE_DRIVER_START( toutrun )
+
+	/* basic machine hardware */
+	MDRV_CPU_ADD(M68000, 12000000)
+	MDRV_CPU_MEMORY(outrun_readmem,outrun_writemem)
+	MDRV_CPU_VBLANK_INT(or_interrupt,2)
+
+	MDRV_CPU_ADD(Z80, 4000000)
+	MDRV_CPU_FLAGS(CPU_AUDIO_CPU)
+	MDRV_CPU_MEMORY(outrun_sound_readmem,outrun_sound_writemem)
+	MDRV_CPU_PORTS(sound_readport,sound_writeport)
+
+	MDRV_CPU_ADD(M68000, 12000000)
+	MDRV_CPU_MEMORY(outrun_readmem2,outrun_writemem2)
+	MDRV_CPU_VBLANK_INT(sys16_interrupt,2)
+
+	MDRV_FRAMES_PER_SECOND(60)
+	MDRV_VBLANK_DURATION(DEFAULT_60HZ_VBLANK_DURATION)
+	MDRV_INTERLEAVE(100)
+
+	MDRV_MACHINE_INIT(outrun)
+
+	/* video hardware */
+	MDRV_VIDEO_ATTRIBUTES(VIDEO_TYPE_RASTER | VIDEO_UPDATE_AFTER_VBLANK)
+	MDRV_SCREEN_SIZE(40*8, 28*8)
+	MDRV_VISIBLE_AREA(0*8, 40*8-1, 0*8, 28*8-1)
+	MDRV_GFXDECODE(sys16_gfxdecodeinfo)
+	MDRV_PALETTE_LENGTH(4096*ShadowColorsMultiplier)
+
+	MDRV_VIDEO_START(outrun)
+	MDRV_VIDEO_UPDATE(outrun)
+
+	/* sound hardware */
+	MDRV_SOUND_ATTRIBUTES(SOUND_SUPPORTS_STEREO)
+	MDRV_SOUND_ADD(YM2151, sys16_ym2151_interface)
+	MDRV_SOUND_ADD(SEGAPCM, sys16_segapcm_interface_15k_512)
+MACHINE_DRIVER_END
 
 static data16_t *shared_ram2;
 static READ16_HANDLER( shared_ram2_r ){
@@ -1533,11 +1607,12 @@ static MACHINE_DRIVER_START( shangon )
 	MDRV_SOUND_ADD(SEGAPCM, sys16_segapcm_interface_15k_512)
 MACHINE_DRIVER_END
 
+
 GAMEX(1992, shangon,  0,        shangon,  shangon,  shangon,  ROT0,         "Sega",    "Super Hang-On", GAME_NOT_WORKING )
 GAME( 1992, shangonb, shangon,  shangon,  shangon,  shangonb, ROT0,         "bootleg", "Super Hang-On (bootleg)" )
 
 GAME( 1986, outrun,   0,        outrun,   outrun,   outrun,   ROT0,         "Sega",    "Out Run (set 1)" )
-GAME( 1986, outruna,  outrun,   outruna,  outrun,   outrun,   ROT0,         "Sega",    "Out Run (set 2)" )
-GAME( 1986, outrunb,  outrun,   outruna,  outrun,   outrunb,  ROT0,         "Sega",    "Out Run (set 3)" )
-GAMEX(19??, toutrun,  0,        outrun,   outrun,   outrun,   ROT0,         "Sega",    "Turbo Outrun (set 1)", GAME_NOT_WORKING )
-GAMEX(19??, toutruna, toutrun,  outrun,   outrun,   outrun,   ROT0,         "Sega",    "Turbo Outrun (set 2)", GAME_NOT_WORKING )
+GAME( 1986, outruna,  outrun,   outrun,   outrun,   outrun,   ROT0,         "Sega",    "Out Run (set 2)" )
+GAME( 1986, outrunb,  outrun,   outrun,   outrun,   outrunb,  ROT0,         "Sega",    "Out Run (set 3)" )
+GAME( 1989, toutrun,  0,        toutrun,  toutrun,  toutrun,  ROT0,         "Sega",    "Turbo Out Run (Out Run upgrade) (bootleg of FD1094 317-0118 set)" ) /* decrypted */
+GAME( 1989, toutrun3, toutrun,  toutrun,  toutrun,  toutrun,  ROT0,         "Sega",    "Turbo Out Run (cockpit) (bootleg of FD1094 317-0107 set)" ) /* decrypted */


### PR DESCRIPTION
2021 arcadez fixes sound and road drawing plus adds decrypted mk8k main cpu roms so the game is fully playable in MAME2003
0.89: smf hooked up Nitro button in Turbo Outrun - Game now playable
0.88u5: Fixed gfx2/sound1 rom loading