### PR TITLE
gcc patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ SPLIT_UP_LINK=0
 CORE_DIR := src
 TARGET_NAME := km_mame2003_xtreme
 
+#gcc 10 sets -fno-common this will patch you to compile until the issue is fixed
+
+CFLAGS += -fcommon
+
 GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
This is a patch to compile with gcc 10 and above. These multiple definition errors should really be fixed  at some point gcc 10 and newer use -fno-common by default which causes this error as it was previously -fcommon

@KMFDManic  make sure you do a make clean before recompiling