### PR TITLE
commented code out when testing in pc

### DIFF
--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -1031,7 +1031,7 @@ static void configure_cyclone_mode (int driverIndex)
       unsigned int *type=(unsigned int *)&(Machine->drv->cpu[i].cpu_type);
       if (*type==CPU_Z80)
       {
-        //*type=CPU_DRZ80;
+        *type=CPU_DRZ80;
         log_cb(RETRO_LOG_INFO, LOGPRE "Replaced Z80\n");
       }
     }


### PR DESCRIPTION
Was testing the core options frontend_list.h options forgot on the pc and forgot to to un-comment this line after because its not doable on the pc . Ive tested  on the pi 3 all seems  good. 

Im going to do a separate validation that all the game names are valid for your core on that list since its from mame2000. This could really help the pi1 to pi3 as well. 

There is no one to really test it though on plus as far as I know. I told mahoney he can decide what he wants to do on plus after you've done some testing. So if you can updated him that would be great. 

Sorry about the mistakes I usually test on the platform that I am  working on just the compile time a pain on the pi 3. I have tested it there though that's how I noticed the z80 wasn't changed. 

