### PR TITLE
fix z80

### DIFF
--- a/src/cpu/m68000_cyclone/c68000.c
+++ b/src/cpu/m68000_cyclone/c68000.c
@@ -1,19 +1,10 @@
 #include "c68000.h"
 #include "driver.h"
 #include "cpuintrf.h"
-#include "cyclone.h"
 #include "memory.h"
 
 
-typedef struct
-{
-	struct Cyclone regs;
-	int pending_interrupts;
-	int (*MAMEIrqCallback)(int int_level);
-} Cyclone_Regs;
-
-static Cyclone_Regs cyclone;
-int *cyclone_ICount=&cyclone.regs.cycles;
+Cyclone_Regs cyclone;
 
 static unsigned int MyCheckPc(unsigned int pc)
 {

--- a/src/cpu/m68000_cyclone/c68000.h
+++ b/src/cpu/m68000_cyclone/c68000.h
@@ -1,7 +1,17 @@
 #ifndef C68000_H
 #define C68000_H
+#include "cyclone.h"
 
-extern int *cyclone_ICount;
+typedef struct
+{
+        struct Cyclone regs;
+        int pending_interrupts;
+        int (*MAMEIrqCallback)(int int_level);
+} Cyclone_Regs;
+
+extern Cyclone_Regs cyclone;
+
+#define cyclone_ICount  cyclone.regs.cycles
 
 #define cyclone_INT_NONE 0							  
 #define cyclone_IRQ_1    1

--- a/src/cpu/z80_drz80/drz80_z80.c
+++ b/src/cpu/z80_drz80/drz80_z80.c
@@ -4,16 +4,7 @@
 #include "drz80_z80.h"
 #include "drz80.h"
 
-typedef struct {
-	struct DrZ80 regs;
-	unsigned int nmi_state;
-	unsigned int irq_state;
-	int previouspc;
-	int (*MAMEIrqCallback)(int int_level);
-} drz80_regs;
-
-static drz80_regs DRZ80;
-int *drz80_ICount=&DRZ80.regs.cycles;
+drz80_regs DRZ80;
 
 #define INT_IRQ 0x01
 #define NMI_IRQ 0x02

--- a/src/cpu/z80_drz80/drz80_z80.h
+++ b/src/cpu/z80_drz80/drz80_z80.h
@@ -3,8 +3,19 @@
 
 #include "cpuintrf.h"
 #include "osd_cpu.h"
+#include "drz80.h"
 
-extern int *drz80_ICount;
+typedef struct {
+	struct DrZ80 regs;
+	unsigned int nmi_state;
+	unsigned int irq_state;
+	int previouspc;
+	int (*MAMEIrqCallback)(int int_level);
+} drz80_regs;
+
+extern  drz80_regs DRZ80;
+
+#define drz80_ICount DRZ80.regs.cycles
 
 extern void drz80_init(void);
 extern void drz80_reset (void *param);

--- a/src/libretro/libretro.c
+++ b/src/libretro/libretro.c
@@ -1025,7 +1025,7 @@ static void configure_cyclone_mode (int driverIndex)
     }
   }
 #endif
-#define enable_z80 0
+#define enable_z80 1
 
 #if (HAS_DRZ80)
   /* Replace Z80 by DRZ80 */


### PR DESCRIPTION
That the z80 fixed at last sometimes its the simplest of things. The 68k cycles didn't really seem to be effected but Ive implemented that correctly as well. 

Sf2 boots with sound
88 games boots 
rygar boots properly.

So thats everything working like it is in mame2000 the default list should be fine to use as well ( The default option).  