### PR TITLE
Slight touch up for titlef and MultiPCM_sh_reset

### DIFF
--- a/src/sndintrf.c
+++ b/src/sndintrf.c
@@ -1091,7 +1091,7 @@ struct snd_interface sndintf[] =
 		MultiPCM_sh_start,
 		MultiPCM_sh_stop,
 		0,
-		0
+		MultiPCM_sh_reset
 	},
 #endif
 #if (HAS_C6280)

--- a/src/sound/multipcm.c
+++ b/src/sound/multipcm.c
@@ -374,7 +374,6 @@ void MultiPCM_sh_reset(void)
 			mpcm[chip].Voices[i].relamt = 0;
 			mpcm[chip].Voices[i].relcount = 0;
 			mpcm[chip].Voices[i].relstage = 0;
-			mpcm[chip].Voices[i].active = 0;
 		}
 	}
 }

--- a/src/sound/multipcm.c
+++ b/src/sound/multipcm.c
@@ -355,6 +355,30 @@ void MultiPCM_sh_stop(void)
 {
 }
 
+void MultiPCM_sh_reset(void)
+{
+	int i, chip;
+
+	for (chip = 0; chip < MAX_MULTIPCM; chip++)
+	{
+		for (i = 0; i < 28; i++)
+		{
+			mpcm[chip].Voices[i].active = 0;
+			mpcm[chip].Voices[i].ptsum = 0;
+			mpcm[chip].Voices[i].ptoffset = 0;
+			mpcm[chip].Voices[i].loop = 0;
+			mpcm[chip].Voices[i].loopst = 0;
+			mpcm[chip].Voices[i].end = 0;
+			mpcm[chip].Voices[i].pan = 0;
+			mpcm[chip].Voices[i].vol = 0;
+			mpcm[chip].Voices[i].relamt = 0;
+			mpcm[chip].Voices[i].relcount = 0;
+			mpcm[chip].Voices[i].relstage = 0;
+			mpcm[chip].Voices[i].active = 0;
+		}
+	}
+}
+
 /* write register */
 static void MultiPCM_reg_w(int chip, int offset, unsigned char data)
 {

--- a/src/sound/multipcm.h
+++ b/src/sound/multipcm.h
@@ -18,6 +18,7 @@ struct MultiPCM_interface
 
 int MultiPCM_sh_start(const struct MachineSound *msound);
 void MultiPCM_sh_stop(void);
+void MultiPCM_sh_reset(void);
 
 WRITE_HANDLER( MultiPCM_reg_0_w );
 READ_HANDLER( MultiPCM_reg_0_r);

--- a/src/vidhrdw/segas32.c
+++ b/src/vidhrdw/segas32.c
@@ -2738,7 +2738,7 @@ VIDEO_UPDATE( multi32 )
 	extern struct osd_create_params video_config;
 	struct rectangle clipleft, clipright;
 	UINT8 enablemask;
-	int remix = -1;
+	int restore = system32_videoram[0x1ff02/2], remix = -1;
 
 /*
    MAME2003-PLUS uses a single screen to draw to where as current mame
@@ -2783,7 +2783,7 @@ VIDEO_UPDATE( multi32 )
 		int i;
 		for (i=0; titlef_mixer[i][0]!=0; i++)
 			if (system32_videoram[0x1ff02/2] == titlef_mixer[i][0])
-			{ 
+			{
 				system32_videoram[0x1ff02/2] = titlef_mixer[i][1];
 				if (titlef_mixer[i][1] != titlef_mixer[i][2])
 					remix = titlef_mixer[i][2];
@@ -2827,6 +2827,8 @@ VIDEO_UPDATE( multi32 )
 		system32_videoram[0x1ff02/2] = remix;
 		enablemask = update_tilemaps(&clipleft);
 	}
+	if (system32_videoram[0x1ff02/2] != restore)
+		system32_videoram[0x1ff02/2] = restore;
 
 	if (system32_displayenable[1] && monitor_setting != 1) /* speed up - disable offscreen monitor */
 		mix_all_layers(1, clipright.min_x, bitmap, &clipleft, enablemask);


### PR DESCRIPTION
Fixes one mixing bug when in a pause action. Also MultiPCM_sh_reset to clear active sounds on reset.